### PR TITLE
Fix #2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst')
-except(IOError, ImportError):
+except:
     long_description = ''
 
 


### PR DESCRIPTION
Install regardless of pypandoc exceptions with long description parsing.

It was throwing a RuntimeException if the README was not included (e.g. when installing from pip).