### PR TITLE
Fixed Rounding Errors

### DIFF
--- a/julian/julian.py
+++ b/julian/julian.py
@@ -111,23 +111,23 @@ def from_jd(jd: float, fmt: str = 'jd') -> datetime:
     j = j+2-12*l
     i = 100*(n-49)+i+l
 
-    year = int(i)
-    month = int(j)
-    day = int(k)
+    year = math.trunc(i)
+    month = math.trunc(j)
+    day = math.trunc(k)
 
     # in microseconds
-    frac_component = int(jdf * (1e6*24*3600))
+    frac_component = math.trunc(jdf * (1e6*24*3600))
 
-    hours = int(frac_component // (1e6*3600))
+    hours = math.trunc(frac_component // (1e6*3600))
     frac_component -= hours * 1e6*3600
 
-    minutes = int(frac_component // (1e6*60))
+    minutes = math.trunc(frac_component // (1e6*60))
     frac_component -= minutes * 1e6*60
 
-    seconds = int(frac_component // 1e6)
+    seconds = math.trunc(frac_component // 1e6)
     frac_component -= seconds*1e6
 
-    frac_component = int(frac_component)
+    frac_component = math.trunc(frac_component)
 
     dt = datetime(year=year, month=month, day=day,
                   hour=hours, minute=minutes, second=seconds, microsecond=frac_component)


### PR DESCRIPTION
updated int() to math.trunc() to prevent rounding errors converting from Julian date to Python datetime object